### PR TITLE
Text selection after Ctrl+L & support for Mac OSX Shortcuts 

### DIFF
--- a/src/Platform_Core/org/lobobrowser/main/OS.java
+++ b/src/Platform_Core/org/lobobrowser/main/OS.java
@@ -1,0 +1,7 @@
+package org.lobobrowser.main;
+
+public enum OS {
+
+  MAC, WINDOWS, UNIX, SOLARIS, UNKNOWN
+
+}

--- a/src/Platform_Core/org/lobobrowser/main/PlatformInit.java
+++ b/src/Platform_Core/org/lobobrowser/main/PlatformInit.java
@@ -76,10 +76,17 @@ import com.squareup.okhttp.Protocol;
  *
  * @see #getInstance()
  */
+
 public class PlatformInit {
   private static final String NATIVE_DIR_NAME = "native";
   private static final long DAYS_MILLIS = 24 * 60 * 60 * 1000L;
   private static final long TIMEOUT_DAYS = 120;
+  private static final String osName = System.getProperty("os.name").toLowerCase();
+  public static final OS OS_NAME = osName.indexOf("win") > -1 ? OS.WINDOWS
+      : (osName.indexOf("mac") > -1 ? OS.MAC
+          : (osName.indexOf("sunos") > -1 ? OS.SOLARIS
+              : (osName.indexOf("nix") > -1 || osName.indexOf("aix") > -1 || osName.indexOf("nux") > -1) ? OS.UNIX : OS.UNKNOWN));
+
   private final SimpleThreadPool threadExecutor;
 
   // private final GeneralSettings generalSettings;
@@ -335,7 +342,8 @@ public class PlatformInit {
             + version
             + "</p><p>Released on: "
             + releaseDate
-            + "</p><p>This version is more than " + TIMEOUT_DAYS + " days old and was not intended for long-time use.</p><p>Please check if a newer version is available on https://gngr.info</p></html>";
+            + "</p><p>This version is more than " + TIMEOUT_DAYS
+            + " days old and was not intended for long-time use.</p><p>Please check if a newer version is available on https://gngr.info</p></html>";
         JOptionPane.showMessageDialog(null, checkForUpdatesMessage);
       }
     } catch (IOException | ParseException e) {

--- a/src/Primary_Extension/org/lobobrowser/primary/ext/AddressField.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/AddressField.java
@@ -75,11 +75,14 @@ public class AddressField extends JComboBox<String> {
       }
     });
 
-    getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ctrl L"), "edit URL");
+    getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        .put(KeyStroke.getKeyStroke(KeyEvent.VK_L, ComponentSource.CMD_CTRL_KEY_MASK), "edit URL");
+
     getActionMap().put("edit URL", new AbstractAction() {
 
       public void actionPerformed(final ActionEvent e) {
         requestFocus();
+        getEditor().selectAll();        
       }
     });
 

--- a/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
@@ -22,6 +22,7 @@ package org.lobobrowser.primary.ext;
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -44,6 +45,8 @@ import javax.swing.KeyStroke;
 import javax.swing.event.MenuEvent;
 
 import org.lobobrowser.gui.ConsoleModel;
+import org.lobobrowser.main.OS;
+import org.lobobrowser.main.PlatformInit;
 import org.lobobrowser.primary.settings.SearchEngine;
 import org.lobobrowser.primary.settings.ToolsSettings;
 import org.lobobrowser.request.ClientletRequestHandler;
@@ -73,7 +76,11 @@ public class ComponentSource implements NavigatorWindowListener {
   private final JButton searchButton;
   private final JButton reqManagerButton;
   private final ActionPool actionPool;
-  private final DirectorySource directorySource;
+  private final DirectorySource directorySource;  
+  
+  // Mask for Key Stroke 
+  public static final int CMD_CTRL_KEY_MASK = PlatformInit.OS_NAME == OS.MAC ? Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()
+      : InputEvent.CTRL_MASK;
 
   public ComponentSource(final NavigatorWindow window) {
     super();
@@ -165,17 +172,17 @@ public class ComponentSource implements NavigatorWindowListener {
   public JMenu getFileMenu() {
     final JMenu openMenu = new JMenu("Open");
     openMenu.setMnemonic('O');
-    openMenu.add(menuItem("New Window", 'N', KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_MASK),
+    openMenu.add(menuItem("New Window", 'N', KeyStroke.getKeyStroke(KeyEvent.VK_N, CMD_CTRL_KEY_MASK),
         this.actionPool.blankWindowAction));
     openMenu.add(menuItem("Cloned Window", 'C', this.actionPool.clonedWindowAction));
-    openMenu.add(menuItem("File...", 'F', "ctrl O", this.actionPool.openFileAction));
+    openMenu.add(menuItem("File...", 'F', KeyStroke.getKeyStroke(KeyEvent.VK_O, CMD_CTRL_KEY_MASK), this.actionPool.openFileAction));
 
     final JMenu menu = new JMenu("File");
     menu.setMnemonic('F');
 
     menu.add(openMenu);
     menu.addSeparator();
-    menu.add(menuItem("Close", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.CTRL_MASK), this.actionPool.exitAction));
+    menu.add(menuItem("Close", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_W, CMD_CTRL_KEY_MASK), this.actionPool.exitAction));
 
     return menu;
   }
@@ -184,7 +191,7 @@ public class ComponentSource implements NavigatorWindowListener {
     final JMenu menu = new JMenu("Edit");
     menu.setMnemonic('E');
 
-    menu.add(menuItem("Copy", 'C', "ctrl C", this.actionPool.copyAction));
+    menu.add(menuItem("Copy", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_C, CMD_CTRL_KEY_MASK), this.actionPool.copyAction));
 
     return menu;
   }
@@ -193,7 +200,7 @@ public class ComponentSource implements NavigatorWindowListener {
     final JMenu menu = new JMenu("View");
     menu.setMnemonic('V');
 
-    menu.add(menuItem("Page Source", 'S', this.actionPool.sourceAction));
+    menu.add(menuItem("Page Source", 'S', KeyStroke.getKeyStroke(KeyEvent.VK_U, CMD_CTRL_KEY_MASK), this.actionPool.sourceAction));
     menu.add(menuItem("Console", 'C', this.actionPool.consoleAction));
 
     return menu;
@@ -214,9 +221,16 @@ public class ComponentSource implements NavigatorWindowListener {
     final JMenu menu = new JMenu("Navigation");
     menu.setMnemonic('N');
 
-    menu.add(menuItem("Back", 'B', "ctrl B", this.actionPool.backAction));
-    menu.add(menuItem("Forward", 'F', this.actionPool.forwardAction));
-    menu.add(menuItem("Stop", 'S', KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), this.actionPool.stopAction));
+    if (PlatformInit.OS_NAME == OS.MAC) {
+      menu.add(menuItem("Back", 'B', KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, CMD_CTRL_KEY_MASK), this.actionPool.backAction));
+      menu.add(
+          menuItem("Forward", 'F', KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, CMD_CTRL_KEY_MASK), this.actionPool.forwardAction));
+      menu.add(menuItem("Stop", 'S', KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), this.actionPool.stopAction));
+    } else {
+      menu.add(menuItem("Back", 'B', "ctrl B", this.actionPool.backAction));
+      menu.add(menuItem("Forward", 'F', this.actionPool.forwardAction));
+      menu.add(menuItem("Stop", 'S', KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), this.actionPool.stopAction));
+    }
 
     final JMenuItem reloadMenuItem = menuItem("Reload", 'R', KeyStroke.getKeyStroke(KeyEvent.VK_F5, 0), this.actionPool.reloadAction);
     reloadMenuItem.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ctrl R"), "reload action");
@@ -235,8 +249,14 @@ public class ComponentSource implements NavigatorWindowListener {
     final JMenu menu = new JMenu("Tools");
     menu.setMnemonic('T');
     menu.add(this.searchersMenu);
-    menu.add(menuItem("Preferences...", 'P', this.actionPool.preferencesAction));
+
+    menu.add((PlatformInit.OS_NAME == OS.MAC)
+        ? menuItem("Preferences...", 'P', KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, CMD_CTRL_KEY_MASK),
+            this.actionPool.preferencesAction)
+        : menu.add(menuItem("Preferences...", 'P', this.actionPool.preferencesAction)));
+
     return menu;
+
   }
 
   public JMenu getDirectoryMenu() {

--- a/src/Primary_Extension/org/lobobrowser/primary/ext/TextViewerWindow.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/TextViewerWindow.java
@@ -24,6 +24,7 @@ import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.WindowEvent;
 
 import javax.swing.JFrame;
@@ -31,6 +32,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
@@ -121,8 +123,8 @@ public class TextViewerWindow extends JFrame {
   private JMenu createEditMenu() {
     final JMenu fileMenu = new JMenu("Edit");
     fileMenu.setMnemonic('E');
-    fileMenu.add(ComponentSource.menuItem("Copy", 'C', "ctrl c", new CopyAction()));
-    fileMenu.add(ComponentSource.menuItem("Select All", 'A', new SelectAllAction()));
+    fileMenu.add(ComponentSource.menuItem("Copy", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_C, ComponentSource.CMD_CTRL_KEY_MASK), new CopyAction()));
+    fileMenu.add(ComponentSource.menuItem("Select All", 'A', KeyStroke.getKeyStroke(KeyEvent.VK_A, ComponentSource.CMD_CTRL_KEY_MASK), new SelectAllAction()));
     return fileMenu;
   }
 


### PR DESCRIPTION
The commit fixes https://github.com/UprootLabs/gngr/issues/159 and https://github.com/UprootLabs/gngr/issues/156 (partially)


* [x] **cmd L** for AddressField focus
* [x] **cmd C** for copy
* [x] **cmd u** for page source
* [x] **cmd O** for opening a file
* [x] **cmd W** for closing tab/window
* [x] **cmd left** & **cmd right** for back/forward
* [ ] **cmd X** & **cmd V** for cut & paste
* [ ] **cmd K** for search
* [ ] **cmd S** for save
* [ ] **cmd shift [** & **cmd shift ]** for tab switching (future)
* [ ] ...

