### PR TITLE
add ability to search by string in address bar

### DIFF
--- a/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
@@ -26,6 +26,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
@@ -682,9 +683,19 @@ public class ComponentSource implements NavigatorWindowListener {
   }
 
   public void navigateOrSearch() {
-    final String addressText = this.addressField.getText();
+    final String addressText = this.addressField.getText().trim();
+    final int periodIdx = addressText.indexOf('.');
+    final int spaceIdx = addressText.indexOf(' ');
+    final int aboutIdx = addressText.indexOf("about:");
     if (addressText.charAt(0) == '?') {
       this.search();
+    } else if ((spaceIdx != -1 || periodIdx == -1) && aboutIdx == -1) {
+      try {
+        URL url = new URL("about:confirmSearch?" + addressText);
+        this.navigate(url);
+      } catch (MalformedURLException e) {
+        window.getTopFrame().alert("Malformed search URL.");
+      }
     } else {
       this.navigate(addressText, RequestType.ADDRESS_BAR);
     }
@@ -693,11 +704,15 @@ public class ComponentSource implements NavigatorWindowListener {
   public void search() {
     final ToolsSettings settings = ToolsSettings.getInstance();
     final SearchEngine searchEngine = settings.getSelectedSearchEngine();
+    final String addressText = this.addressField.getText();
     if (searchEngine != null) {
       try {
-        final String addressText = this.addressField.getText();
-        assert (addressText.charAt(0) == '?');
-        this.navigate(searchEngine.getURL(addressText.substring(1)));
+        if (addressText.charAt(0) == '?') {
+          assert (addressText.charAt(0) == '?');
+          this.navigate(searchEngine.getURL(addressText.substring(1)));
+        } else {
+        this.navigate(searchEngine.getURL(addressText));
+        }
       } catch (final java.net.MalformedURLException mfu) {
         window.getTopFrame().alert("Malformed search URL.");
       }

--- a/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
@@ -691,7 +691,7 @@ public class ComponentSource implements NavigatorWindowListener {
       this.search();
     } else if ((spaceIdx != -1 || periodIdx == -1) && aboutIdx == -1) {
       try {
-        URL url = new URL("about:confirmSearch?" + addressText);
+        final URL url = new URL("about:confirmSearch?" + addressText);
         this.navigate(url);
       } catch (MalformedURLException e) {
         window.getTopFrame().alert("Malformed search URL.");


### PR DESCRIPTION
This fix is for #165 that allows strings typed into the address bar to be searchable by default search engine.

There is also a small fix to prevent the browser search button from always searching for urlText.substring(1).