### PR TITLE
fix cut, copy and paste for OSX bindings

### DIFF
--- a/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/ext/ComponentSource.java
@@ -45,6 +45,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.KeyStroke;
 import javax.swing.event.MenuEvent;
+import javax.swing.text.DefaultEditorKit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.lobobrowser.gui.ConsoleModel;
@@ -194,7 +195,9 @@ public class ComponentSource implements NavigatorWindowListener {
     final JMenu menu = new JMenu("Edit");
     menu.setMnemonic('E');
 
-    menu.add(menuItem("Copy", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_C, CMD_CTRL_KEY_MASK), this.actionPool.copyAction));
+    menu.add(menuItem("Cut", 'X', KeyStroke.getKeyStroke(KeyEvent.VK_X, CMD_CTRL_KEY_MASK), new DefaultEditorKit.CutAction()));
+    menu.add(menuItem("Copy", 'C', KeyStroke.getKeyStroke(KeyEvent.VK_C, CMD_CTRL_KEY_MASK), new DefaultEditorKit.CopyAction()));
+    menu.add(menuItem("Paste", 'V', KeyStroke.getKeyStroke(KeyEvent.VK_V, CMD_CTRL_KEY_MASK), new DefaultEditorKit.PasteAction()));
 
     return menu;
   }


### PR DESCRIPTION
This is a quick fix to allow cut, copy and paste for OS X related to #156. This fix passes the standardized test of copying `Welcome to ginger` and pasting it into the address bar. Can anyone else running OS X verify this works for them?

I replaced the Action Pool `copy` method because it was failing in certain cases. Does this change cause any issues for anybody else?

I have a better idea how to improve this (and include Select All) but it might require a significant overhaul and seems to only be an issue for OS X anyway, right?