### PR TITLE
Encoding fix (#243)

### DIFF
--- a/src/Platform_Core/build.xml
+++ b/src/Platform_Core/build.xml
@@ -73,7 +73,7 @@
     </target>
     <target name="EntryPoint">
         <java classname="org.lobobrowser.main.EntryPoint" failonerror="true" fork="yes">
-            <jvmarg line="-Dext.dirs=../XAMJ_Build/ext  -Dext.files=../HTML_Renderer/bin,../Primary_Extension/bin  -Djava.security.debugxx=accesss,failure -Djava.security.debugxx=access,domain,stack"/>
+            <jvmarg line="-Dfile.encoding=utf-8 -Dext.dirs=../XAMJ_Build/ext  -Dext.files=../HTML_Renderer/bin,../Primary_Extension/bin  -Djava.security.debugxx=accesss,failure -Djava.security.debugxx=access,domain,stack"/>
             <arg value="-debug"/>
             <arg value="-grinder-key=${gngr.grinder.key}" if:set="gngr.grinder.key"/>
             <classpath refid="Platform_Core.classpath"/>


### PR DESCRIPTION
Since there is not ANT_OPTS in build.xml and in order to maintain the user's machine state the encoding opt was added in build.xml at the EntryPoint target, thus not changing the machine status and runing the program with the asked enconding (#243)

Closes #243 