### PR TITLE
Warning clear

### DIFF
--- a/src/HTML_Renderer/org/lobobrowser/html/domimpl/HTMLBaseInputElement.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/domimpl/HTMLBaseInputElement.java
@@ -369,7 +369,7 @@ public abstract class HTMLBaseInputElement extends HTMLAbstractUIElement {
   public void removeImageListener(final ImageListener listener) {
     final ArrayList<ImageListener> l = this.imageListeners;
     synchronized (l) {
-      l.remove(l);
+      l.remove(listener);
     }
   }
 

--- a/src/HTML_Renderer/org/lobobrowser/html/domimpl/HTMLImageElementImpl.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/domimpl/HTMLImageElementImpl.java
@@ -257,7 +257,7 @@ public class HTMLImageElementImpl extends HTMLAbstractUIElement implements HTMLI
   public void removeImageListener(final ImageListener listener) {
     final ArrayList<ImageListener> l = this.listeners;
     synchronized (l) {
-      l.remove(l);
+      l.remove(listener);
     }
   }
 

--- a/src/HTML_Renderer/org/lobobrowser/html/gui/HtmlBlockPanel.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/gui/HtmlBlockPanel.java
@@ -702,20 +702,21 @@ public class HtmlBlockPanel extends JComponent implements NodeRenderer, Renderab
     // drawGrid(g);
   }
 
-  private void drawGrid(final Graphics g) {
-      final int GRID_SIZE = 50;
-      final int OFFSET_X = 0;
-      final int OFFSET_Y = 0;
-      // Draw grid for debug
-      final Rectangle clipBounds = g.getClipBounds();
-      g.setColor(new Color(0, 0, 0, 30));
-      for (int i = 0; i < clipBounds.width; i+= GRID_SIZE) {
-        g.drawLine(i + OFFSET_X, 0, i + OFFSET_X, clipBounds.height);
-      }
-      for (int j = 0; j < clipBounds.height; j+= GRID_SIZE) {
-        g.drawLine(0, j + OFFSET_Y, clipBounds.width, j + OFFSET_Y);
-      }
-  }
+  //For debugging
+//  private void drawGrid(final Graphics g) {
+//      final int GRID_SIZE = 50;
+//      final int OFFSET_X = 0;
+//      final int OFFSET_Y = 0;
+//      // Draw grid for debug
+//      final Rectangle clipBounds = g.getClipBounds();
+//      g.setColor(new Color(0, 0, 0, 30));
+//      for (int i = 0; i < clipBounds.width; i+= GRID_SIZE) {
+//        g.drawLine(i + OFFSET_X, 0, i + OFFSET_X, clipBounds.height);
+//      }
+//      for (int j = 0; j < clipBounds.height; j+= GRID_SIZE) {
+//        g.drawLine(0, j + OFFSET_Y, clipBounds.width, j + OFFSET_Y);
+//      }
+//  }
 
   @Override
   public void doLayout() {

--- a/src/HTML_Renderer/org/lobobrowser/html/io/WritableLineReader.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/io/WritableLineReader.java
@@ -28,6 +28,10 @@ import java.io.LineNumberReader;
 import java.io.Reader;
 
 public class WritableLineReader extends LineNumberReader {
+  @SuppressWarnings("unused")
+  // by heritance this object already has a reader with the attribute name "lock"
+  // this shouldn't be needed
+  // TODO delete and refactor code
   private final Reader delegate;
 
   public WritableLineReader(final Reader reader, final int bufferSize) {

--- a/src/HTML_Renderer/org/lobobrowser/html/js/Window.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/js/Window.java
@@ -432,7 +432,7 @@ public class Window extends AbstractScriptableDelegate implements AbstractView, 
     public int addUniqueJSTask(final int oldId, final JSTask task, final UserAgentContext uaContext, final URL urlContext) {
       // synchronized (this) {
       if (oldId != -1) {
-        if (jsQueue.contains(oldId)) {
+        if (jsQueue.stream().anyMatch(scheduleTask -> scheduleTask.id==oldId)) {
           return oldId;
         }
         /*

--- a/src/HTML_Renderer/org/lobobrowser/html/parser/HtmlParser.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/parser/HtmlParser.java
@@ -60,7 +60,11 @@ import org.xml.sax.SAXException;
  * may be used directly when a different DOM implementation is preferred.
  */
 public class HtmlParser {
-  private static final Logger logger = Logger.getLogger(HtmlParser.class.getName());
+  public ErrorHandler getErrorHandler() {
+		return errorHandler;
+	}
+
+private static final Logger logger = Logger.getLogger(HtmlParser.class.getName());
   private final Document document;
   private final UserAgentContext ucontext;
   private final ErrorHandler errorHandler;

--- a/src/HTML_Renderer/org/lobobrowser/html/renderer/BaseBlockyRenderable.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/renderer/BaseBlockyRenderable.java
@@ -1,8 +1,5 @@
 package org.lobobrowser.html.renderer;
 
-import java.awt.Graphics;
-import java.awt.event.MouseEvent;
-
 import org.lobobrowser.html.domimpl.ModelNode;
 import org.lobobrowser.ua.UserAgentContext;
 

--- a/src/HTML_Renderer/org/lobobrowser/html/renderer/InputSelectControl.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/renderer/InputSelectControl.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 import javax.swing.DefaultListModel;
 import javax.swing.JComboBox;
@@ -310,8 +311,12 @@ class InputSelectControl extends BaseInputControl {
       final OptionItem item = (OptionItem) this.comboBox.getSelectedItem();
       return item == null ? null : new String[] { item.getValue() };
     } else {
-      final Object[] values = this.list.getSelectedValues();
-      if (values == null) {
+      final List<OptionItem> values = this.list.getSelectedValuesList();
+      if (values == null
+    		  || values.isEmpty()) {
+    	  //TODO the empty validation wasn't here, it was added because the called method
+    	  // returns an empty list instead of null - confirm if this extra verification
+    	  // isn't harmful as the code didn't had it
         return null;
       }
       final ArrayList<String> al = new ArrayList<>();

--- a/src/HTML_Renderer/org/lobobrowser/html/renderer/RBlock.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/renderer/RBlock.java
@@ -395,16 +395,8 @@ public class RBlock extends BaseBlockyRenderable {
         // this.lastLayoutKey = key;
         // this.lastLayoutValue = value;
       }
-    } else {
-      /*
-      System.out.println("Cached layout for " + this);
-      final FloatingInfo finfo = getExportableFloatingInfo();
-      if (finfo != null) {
-        for ( ExportableFloat fi : finfo.floats) {
-          fi.pendingPlacement = true;
-        }
-      }*/
     }
+    
     this.width = value.width;
     this.height = value.height;
     this.hasHScrollBar = value.hasHScrollBar;

--- a/src/HTML_Renderer/org/lobobrowser/html/renderer/RBlockViewport.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/renderer/RBlockViewport.java
@@ -115,6 +115,10 @@ public class RBlockViewport extends BaseRCollection {
   private int maxY;
   // private int availHeight;
   private int desiredWidth; // includes insets
+  public int getDesiredHeight() {
+	return desiredHeight;
+}
+
   private int desiredHeight; // includes insets
   private int availContentHeight; // does not include insets
   private int availContentWidth; // does not include insets
@@ -199,14 +203,15 @@ public class RBlockViewport extends BaseRCollection {
     return this.availContentWidth;
   }
 
-  private int initCollapsibleMargin() {
-    final Object parent = this.parent;
-    if (!(parent instanceof RBlock)) {
-      return 0;
-    }
-    final RBlock parentBlock = (RBlock) parent;
-    return parentBlock.getCollapsibleMarginTop();
-  }
+//	Might still be useful
+//  private int initCollapsibleMargin() {
+//    final Object parent = this.parent;
+//    if (!(parent instanceof RBlock)) {
+//      return 0;
+//    }
+//    final RBlock parentBlock = (RBlock) parent;
+//    return parentBlock.getCollapsibleMarginTop();
+//  }
 
   /**
    * Builds the layout/renderer tree from scratch. Note: Returned dimension
@@ -349,22 +354,22 @@ public class RBlockViewport extends BaseRCollection {
         final Insets insets = this.paddingInsets;
         // final FloatingBounds floatBounds = this.floatBounds;
         final int numRenderables = renderables.size();
-        final int yoffset = 0; // This may get adjusted due to blocks and floats.
+//        final int yoffset = 0;  This may get adjusted due to blocks and floats.
         for (int i = 0; i < numRenderables; i++) {
           final Object r = renderables.get(i);
           if (r instanceof BoundableRenderable) {
             final BoundableRenderable seqRenderable = (BoundableRenderable) r;
             final int y = seqRenderable.getY();
-            int newY;
-            if (yoffset > 0) {
-              newY = y + yoffset;
-              seqRenderable.setY(newY);
-              if ((newY + seqRenderable.getHeight()) > this.maxY) {
-                this.maxY = newY + seqRenderable.getHeight();
-              }
-            } else {
-              newY = y;
-            }
+//            int newY;
+//            if (yoffset > 0) {
+//              newY = y + yoffset;
+//              seqRenderable.setY(newY);
+//              if ((newY + seqRenderable.getHeight()) > this.maxY) {
+//                this.maxY = newY + seqRenderable.getHeight();
+//              }
+//            } else {
+//              newY = y;
+//            }
             final boolean isVisibleBlock = (seqRenderable instanceof RBlock) && ((RBlock) seqRenderable).isOverflowVisibleX();
             final int leftOffset = isVisibleBlock ? insets.left : this.fetchLeftOffset(y);
             final int rightOffset = isVisibleBlock ? insets.right : this.fetchRightOffset(y);

--- a/src/HTML_Renderer/org/lobobrowser/html/renderer/RListItem.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/renderer/RListItem.java
@@ -36,7 +36,7 @@ class RListItem extends BaseRListElement {
   private static final int BULLET_WIDTH = 5;
   private static final int BULLET_HEIGHT = 5;
   private static final int BULLET_RMARGIN = 5;
-  private static final int BULLET_SPACE_WIDTH = 36;
+  // private static final int BULLET_SPACE_WIDTH = 36;
 
   public RListItem(final NodeImpl modelNode, final int listNesting, final UserAgentContext pcontext, final HtmlRendererContext rcontext,
       final FrameContext frameContext,

--- a/src/HTML_Renderer/org/lobobrowser/html/style/StyleSheetRenderState.java
+++ b/src/HTML_Renderer/org/lobobrowser/html/style/StyleSheetRenderState.java
@@ -392,10 +392,12 @@ public class StyleSheetRenderState implements RenderState {
     return tt;
   }
 
+  @SuppressWarnings("deprecation")
   public final FontMetrics getFontMetrics() {
     FontMetrics fm = this.iFontMetrics;
     if (fm == null) {
       // TODO getFontMetrics deprecated. How to get text width?
+      // sugestion: using LineMetrics instead 
       fm = Toolkit.getDefaultToolkit().getFontMetrics(this.getFont());
       this.iFontMetrics = fm;
     }

--- a/src/Platform_Core/build.xml
+++ b/src/Platform_Core/build.xml
@@ -73,7 +73,7 @@
     </target>
     <target name="EntryPoint">
         <java classname="org.lobobrowser.main.EntryPoint" failonerror="true" fork="yes">
-            <jvmarg line="-Dext.dirs=../XAMJ_Build/ext  -Dext.files=../HTML_Renderer/bin,../Primary_Extension/bin  -Djava.security.debugxx=accesss,failure -Djava.security.debugxx=access,domain,stack"/>
+            <jvmarg line="-Dfile.encoding=utf-8 -Dext.dirs=../XAMJ_Build/ext  -Dext.files=../HTML_Renderer/bin,../Primary_Extension/bin  -Djava.security.debugxx=accesss,failure -Djava.security.debugxx=access,domain,stack"/>
             <arg value="-debug"/>
             <arg value="-grinder-key=${gngr.grinder.key}" if:set="gngr.grinder.key"/>
             <classpath refid="Platform_Core.classpath"/>

--- a/src/Platform_Core/org/lobobrowser/main/ReuseServer.java
+++ b/src/Platform_Core/org/lobobrowser/main/ReuseServer.java
@@ -133,7 +133,6 @@ public class ReuseServer implements Runnable {
               } else if ("GRINDER".equals(command)) {
                 final DataOutputStream dos = new DataOutputStream(s.getOutputStream());
                 if (blankIdx != -1) {
-                  @SuppressWarnings("null")
                   final @NonNull String key = line.substring(blankIdx + 1).trim();
                   if (PlatformInit.getInstance().verifyAuth(ss.getLocalPort(), key)) {
                     final NavigatorFrame frame = PlatformInit.getInstance().launch("about:blank");

--- a/src/Platform_Core/org/lobobrowser/request/CookieParsing.java
+++ b/src/Platform_Core/org/lobobrowser/request/CookieParsing.java
@@ -2,7 +2,6 @@ package org.lobobrowser.request;
 
 import java.net.URI;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.DateTimeException;
 import java.time.OffsetDateTime;
@@ -19,6 +18,9 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@SuppressWarnings("unused")
+//Surpress the EXPIRES_FORMAT unused warning - attributes seemed
+// important despite being private
 final class CookieParsing {
   private static final Logger logger = Logger.getLogger(CookieParsing.class.getName());
   private static final DateFormat EXPIRES_FORMAT;
@@ -38,31 +40,6 @@ final class CookieParsing {
     EXPIRES_FORMAT = ef1;
     EXPIRES_FORMAT_BAK1 = ef2;
     EXPIRES_FORMAT_BAK2 = ef3;
-  }
-
-  /** @deprecated Use parseExpiresRFC6265 instead */
-  @Deprecated
-  private static Optional<java.util.Date> parseExpires(final String expiresStr) {
-    Optional<java.util.Date> expiresDate = Optional.empty();
-    synchronized (EXPIRES_FORMAT) {
-      try {
-        expiresDate = Optional.of(EXPIRES_FORMAT.parse(expiresStr));
-      } catch (final Exception pe) {
-        if (logger.isLoggable(Level.INFO)) {
-          logger.log(Level.INFO, "parseExpires(): Bad date format: " + expiresStr + ". Will try again.", pe);
-        }
-        try {
-          expiresDate = Optional.of(EXPIRES_FORMAT_BAK1.parse(expiresStr));
-        } catch (final Exception pe2) {
-          try {
-            expiresDate = Optional.of(EXPIRES_FORMAT_BAK2.parse(expiresStr));
-          } catch (final ParseException pe3) {
-            logger.log(Level.SEVERE, "parseExpires(): Giving up on cookie date format: " + expiresStr, pe3);
-          }
-        }
-      }
-    }
-    return expiresDate;
   }
 
   static Optional<CookieDetails> parseCookieSpec(final URI requestURL, final String cookieSpec) {

--- a/src/Platform_Core/org/lobobrowser/request/CookieStore.java
+++ b/src/Platform_Core/org/lobobrowser/request/CookieStore.java
@@ -51,8 +51,6 @@ import info.gngr.db.tables.records.CookiesRecord;
  * @author J. H. S.
  */
 public class CookieStore {
-  private static final String COOKIE_PATH_PREFIX = ".W$Cookies/";
-  private static final String COOKIE_PATH_PATTERN = "\\.W\\$Cookies/.*";
   private static final CookieStore instance = new CookieStore();
 
   private static final Logger logger = Logger.getLogger(CookieStore.class.getName());
@@ -139,17 +137,6 @@ public class CookieStore {
       previousTimeNanos = currentNanos;
       return currentNanos;
     }
-  }
-
-  private static String getPathFromCookieName(final String cookieName) {
-    return COOKIE_PATH_PREFIX + cookieName;
-  }
-
-  private static String getCookieNameFromPath(final String path) {
-    if (!path.startsWith(COOKIE_PATH_PREFIX)) {
-      throw new IllegalArgumentException("Invalid path: " + path);
-    }
-    return path.substring(COOKIE_PATH_PREFIX.length());
   }
 
   /* Path-match algorithm as per section 5.4.1 of RFC 6264. */

--- a/src/Platform_Core/org/lobobrowser/request/CookieValue.java
+++ b/src/Platform_Core/org/lobobrowser/request/CookieValue.java
@@ -48,7 +48,11 @@ public class CookieValue implements Comparable<CookieValue> {
     this.creationTime = creationTime;
   }
 
-  public String getName() {
+  public boolean isHttpOnly() {
+	return httpOnly;
+}
+
+public String getName() {
     return this.name;
   }
 

--- a/src/Platform_Core/org/lobobrowser/request/RequestEngine.java
+++ b/src/Platform_Core/org/lobobrowser/request/RequestEngine.java
@@ -728,13 +728,14 @@ public final class RequestEngine {
     }
   }
 
-  private static void dumpResponseInfo(final URLConnection connection) {
-    if (PlatformInit.getInstance().debugOn) {
-      System.out.println("URL: " + connection.getURL());
-      System.out.println("  Response Headers: ");
-      connection.getHeaderFields().forEach((key, value) -> System.out.println("    " + key + " : " + value));
-    }
-  }
+// It is referenced in this class so the method stays in case it's needed in the future
+//  private static void dumpResponseInfo(final URLConnection connection) {
+//    if (PlatformInit.getInstance().debugOn) {
+//      System.out.println("URL: " + connection.getURL());
+//      System.out.println("  Response Headers: ");
+//      connection.getHeaderFields().forEach((key, value) -> System.out.println("    " + key + " : " + value));
+//    }
+//  }
 
   private void processHandler(final RequestHandler rhandler, final int recursionLevel, final boolean trackRequestInfo) {
     // Method must be private.

--- a/src/Primary_Extension/org/lobobrowser/primary/clientlets/html/HtmlClientlet.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/clientlets/html/HtmlClientlet.java
@@ -247,15 +247,6 @@ public final class HtmlClientlet implements Clientlet {
     return locales;
   }
 
-  private static String getDefaultCharset(final URL url) {
-    if (Urls.isLocalFile(url)) {
-      final String charset = System.getProperty("file.encoding");
-      return charset == null ? "ISO-8859-1" : charset;
-    } else {
-      return "ISO-8859-1";
-    }
-  }
-
   private final static RefreshInfo extractRefresh(final String refresh) {
     String delayText = null;
     String urlText = null;

--- a/src/Primary_Extension/org/lobobrowser/primary/gui/download/DownloadDialog.java
+++ b/src/Primary_Extension/org/lobobrowser/primary/gui/download/DownloadDialog.java
@@ -195,6 +195,8 @@ public class DownloadDialog extends JFrame {
     return box;
   }
 
+  @SuppressWarnings("unused")
+  //Warning surpressed because there is a TODO with this method
   private void selectFile() {
     final String path = this.url.getPath();
     final int lastSlashIdx = path.lastIndexOf('/');

--- a/src/Primary_Extension/org/lobobrowser/protocol/about/AboutURLConnection.java
+++ b/src/Primary_Extension/org/lobobrowser/protocol/about/AboutURLConnection.java
@@ -369,10 +369,6 @@ public class AboutURLConnection extends URLConnection {
       return historyEntry;
     }
 
-    public int getScore() {
-      return score;
-    }
-
     public int compareTo(final ScoredEntry o) {
       if (this == o) {
         return 0;


### PR DESCRIPTION
This commit served the purpose of cleaning off the warning messages. Fixes used:

* Code deletion (dead code)
* Code commenting (when dead code once made sense because it can make sense in the future)
* Code fixing (wrong argument types and others)
* SuppressWarnings (most have comments to get rid of the suppress by refactoring the code - it just didn't seem right to have it in this issue since it were some deep enough refactors)
* Getters (for not used attributes so far but that made sense to stay in the code)

**One** warning remaining that I couldn't get rid off: The expression of type Iterator[] needs unchecked conversion to conform to Iterator<Renderable>[] @ RTable.java. Please see if a suppressWarning would make since (in my opinion, no, but I just couldn't see an answer for this).

Some suppressWarnings I put in are probably material to open new issues (code replace and refactoring and such in need) - I ask the maintainers to check them out and open new issues if that's the case. You can assign them to me, I just thought it wasn't material for this issue.