### PR TITLE
Add .idea directory to root .gitignore (IntelliJ IDEA configs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .metadata
 *.swp
 *.iml
+.idea/


### PR DESCRIPTION
Saw that *.iml files are ignored but not the .idea directory. This PR should make life easier for those working in IntelliJ.